### PR TITLE
update the product tag and default build

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,11 +1,11 @@
 {
-    "productTag": "a1aB0000000CTj9IAG",
-    "issueTypeLabels": {
-	"bug":"BUG P3",
-	"security":"BUG P2",
-	"enhancement":"USER STORY"
-	},
-    "hideWorkItemUrl": "true",
-    "statusWhenClosed": "CLOSED",
-    "defaultBuild": "offcore.tooling.48"
+  "productTag": "a1aB0000000YP4JIAW",
+  "issueTypeLabels": {
+    "bug": "BUG P3",
+    "security": "BUG P2",
+    "enhancement": "USER STORY"
+  },
+  "hideWorkItemUrl": "true",
+  "statusWhenClosed": "CLOSED",
+  "defaultBuild": "offcore.tooling.52"
 }


### PR DESCRIPTION
This PR will update the product tag from `Code Builder` to `CodeBuilder Platform` so WI are created for the correct team.