### PR TITLE
docs: add Aug 2026 release notes — scratch orgs and static IP

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -4,6 +4,16 @@ Each release typically contains bug fixes, as well as performance and security e
 
 These release notes outline the changes of note in the latest Agentforce Vibes IDE release.
 
+## Aug 6 2026
+
+**Agentforce Vibes IDE in Scratch Orgs**
+
+Agentforce Vibes IDE is now available in scratch orgs. Enterprise, Professional, and Unlimited Edition scratch orgs get access automatically—no changes to your scratch org definition file needed. For Developer Edition scratch orgs, add the `AgentforceVibesIDEForDE` feature to your scratch org definition file to enable access. See [Scratch Org Features](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs_def_file_config_values.htm) for details.
+
+**Static IP for Agentforce Vibes IDE (Developer Preview)**
+
+As a developer preview, Agentforce Vibes IDE workspaces now operate from a predictable set of static IP addresses. This makes it easier to configure trusted IP ranges in your org's network settings when IP-based access policies are in place.
+
 ## Mar 16 2026
 
 **Enhanced security for org authorization in Agentforce Vibes IDE**


### PR DESCRIPTION
## Summary

- Adds **Agentforce Vibes IDE in Scratch Orgs** entry for Aug 6 2026 — covers automatic access for EE/Pro/Unlimited scratch orgs and the `AgentforceVibesIDEForDE` opt-in for DE scratch orgs, per Shalini's CX language from salesforcedocs/salesforcedx#287
- Adds **Static IP for Agentforce Vibes IDE (Developer Preview)** entry — flags the trusted-IP feature as developer preview per the 262.13 gating timeline

## Context

Requested by Nitin Arora after standup on Aug 5. Scratch org copy is grounded in Shalini's official CX language (salesforcedocs/salesforcedx#287). Static IP entry is minimal and marked Developer Preview since legal approval for full documentation is still pending.

## Test plan

- [ ] Read through both entries for tone consistency with existing changelog entries
- [ ] Verify `AgentforceVibesIDEForDE` feature name is spelled correctly
- [ ] Confirm static IP is still in Developer Preview at publish time
- [ ] Coordinate publish timing with 262.13 patch stagger (started Aug 6)